### PR TITLE
guild: CLI (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,25 @@ cargo build --release
 ### Start the daemon
 
 ```
-cargo run -- --repo owner/repo --label guild
+guild start owner/repo
+```
+
+Or with non-default options:
+
+```
+guild start owner/repo \
+  --label guild \
+  --poll-interval 30 \
+  --model claude-opus-4.6 \
+  --max-concurrent 5 \
+  --no-tui
+```
+
+Alternatively, run directly with cargo:
+
+```
+cd daemon
+cargo run -- start owner/repo
 ```
 
 That's it. The daemon starts polling. To process an issue:

--- a/guild
+++ b/guild
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec cargo run --quiet --manifest-path "$SCRIPT_DIR/daemon/Cargo.toml" -- "$@"


### PR DESCRIPTION
Closes #11

## Problem

We start this service something like this:

```
cd guild
cd deamon

cargo run -- start myorg/myapp
```
OR with non-defaults
```
cargo run -- start myorg/myapp \
  --label guild \
  --poll-interval 30 \
  --model claude-opus-4.6 \
  --max-concurrent 5 \
  --no-tui
```

This is a bit dull.

---
*Generated by [guild](https://github.com/KaugaKauga/guild)*