### PR TITLE
guild: Cleanup on work finished (#10)

### DIFF
--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -324,6 +324,7 @@ async fn run_start(config: Config, no_tui: bool) -> Result<()> {
                     error!(issue = issue_number, "failed to complete pipeline: {:#}", e);
                 } else {
                     info!(issue = issue_number, "completed pipeline moved to ledger");
+                    p.cleanup_worktree();
                     housekeeping_keys.push(issue_number);
                 }
             } else if p.is_failed() && !active_on_github.contains(&issue_number) {
@@ -334,6 +335,7 @@ async fn run_start(config: Config, no_tui: bool) -> Result<()> {
                 if let Err(e) = db.remove_pipeline(issue_number) {
                     error!(issue = issue_number, "failed to remove pipeline: {:#}", e);
                 } else {
+                    p.cleanup_worktree();
                     housekeeping_keys.push(issue_number);
                 }
             }
@@ -450,6 +452,8 @@ async fn run_start(config: Config, no_tui: bool) -> Result<()> {
                         info!(issue = key, "pipeline completed, recording in ledger");
                         if let Err(e) = db.complete_pipeline(&pipeline) {
                             error!(issue = key, "failed to complete pipeline: {:#}", e);
+                        } else {
+                            pipeline.cleanup_worktree();
                         }
                     }
                 }

--- a/daemon/src/pipeline.rs
+++ b/daemon/src/pipeline.rs
@@ -549,20 +549,34 @@ impl Pipeline {
         hasher.update(fingerprint_input.as_bytes());
         let fingerprint = hex::encode(hasher.finalize());
 
-        // Done condition: all checks green, review approved (or none), state open,
-        // and no @guild comments or change-request reviews pending.
-        let all_checks_pass = failed_checks.is_empty();
-        let review_ok = status.review_decision == "APPROVED" || status.review_decision.is_empty();
-        let state_ok = status.state == "OPEN" || status.state == "open";
-        let no_actionable = guild_comments.is_empty() && review_comments.is_empty();
-
-        if all_checks_pass && review_ok && state_ok && no_actionable {
-            info!(
-                "PR #{} is green with no actionable feedback! Marking done.",
-                pr_number
-            );
+        // Done condition: PR has been merged. The worktree is kept alive until
+        // merge so the agent can still push follow-up fixes if reviewers request
+        // changes between submission and merge.
+        let is_merged = status.state == "MERGED" || status.state == "merged";
+        if is_merged {
+            info!("PR #{} has been merged! Marking done.", pr_number);
             self.stage = Stage::Done;
             return Ok(true);
+        }
+
+        // If the PR is closed without merging, mark as failed.
+        let is_closed = status.state == "CLOSED" || status.state == "closed";
+        if is_closed {
+            info!("PR #{} was closed without merging.", pr_number);
+            self.stage = Stage::Failed("PR closed without merging".to_string());
+            return Ok(true);
+        }
+
+        // Ready condition: all checks green, review approved (or none), state open,
+        // and no @guild comments or change-request reviews pending. Nothing to do —
+        // keep watching and wait for the PR to be merged.
+        let all_checks_pass = failed_checks.is_empty();
+        let review_ok = status.review_decision == "APPROVED" || status.review_decision.is_empty();
+        let no_actionable = guild_comments.is_empty() && review_comments.is_empty();
+
+        if all_checks_pass && review_ok && no_actionable {
+            // PR is green; waiting for a human to merge it.
+            return Ok(false);
         }
 
         // Check if blocker fingerprint changed.

--- a/daemon/src/pipeline.rs
+++ b/daemon/src/pipeline.rs
@@ -149,6 +149,26 @@ impl Pipeline {
         matches!(self.stage, Stage::Failed(_))
     }
 
+    /// Remove the worktree directory to reclaim disk space.
+    /// Called after a pipeline is completed or removed.
+    /// Idempotent: does nothing if the directory doesn't exist.
+    pub fn cleanup_worktree(&self) {
+        if self.worktree.exists() {
+            match fs::remove_dir_all(&self.worktree) {
+                Ok(()) => info!(
+                    issue = self.issue_number,
+                    path = %self.worktree.display(),
+                    "cleaned up worktree"
+                ),
+                Err(e) => tracing::warn!(
+                    issue = self.issue_number,
+                    path = %self.worktree.display(),
+                    "failed to clean up worktree: {:#}", e
+                ),
+            }
+        }
+    }
+
     // ------------------------------------------------------------------
     // Stage implementations
     // ------------------------------------------------------------------


### PR DESCRIPTION
Closes #10

## Problem

When work done by Guild is finished ( PR gets merged ) we need to cleanup local git worktree. If not the Guild folder will just continue to grow and grow.

---
*Generated by [guild](https://github.com/KaugaKauga/guild)*