### PR TITLE
guild: CLI improvements (#13)

### DIFF
--- a/daemon/src/copilot.rs
+++ b/daemon/src/copilot.rs
@@ -13,11 +13,13 @@
 //! All intelligence lives in the copilot process itself. This module is
 //! intentionally thin glue.
 
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
 use std::process::Stdio;
 
 use anyhow::{bail, Context, Result};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 /// Run the copilot CLI with the given prompt file in the given working directory.
 ///
@@ -25,23 +27,55 @@ use tracing::{error, info};
 /// full permissions:
 ///   copilot -p <content> --yolo --no-ask-user
 ///
-/// stdout and stderr are inherited so copilot output streams to our terminal.
+/// Output is redirected to log files under `run_dir` to avoid corrupting the
+/// TUI dashboard. Log files are named after the prompt file stem, e.g.
+/// `copilot_plan.log` for `prompt_plan.md`.
+///
 /// stdin is nulled out -- no interactive input.
 pub async fn run_copilot(
     copilot_cmd: &str,
     model: &str,
     prompt_file: &Path,
     work_dir: &Path,
+    run_dir: &Path,
 ) -> Result<()> {
     // Read the prompt file content to pass via -p.
     let content = tokio::fs::read_to_string(prompt_file)
         .await
         .with_context(|| format!("failed to read prompt file: {}", prompt_file.display()))?;
 
+    // Derive log file name from prompt file stem (e.g. prompt_plan -> copilot_plan.log).
+    let stage_name = prompt_file
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("copilot")
+        .strip_prefix("prompt_")
+        .unwrap_or("unknown");
+    let log_name = format!("copilot_{stage_name}.log");
+    let log_path = run_dir.join(&log_name);
+
+    // Open a log file for stdout/stderr. Fall back to Stdio::null() on failure.
+    let (stdout_cfg, stderr_cfg) = match File::create(&log_path) {
+        Ok(out_file) => {
+            let err_file = out_file
+                .try_clone()
+                .context("failed to clone log file handle for stderr")?;
+            (Stdio::from(out_file), Stdio::from(err_file))
+        }
+        Err(e) => {
+            warn!(
+                path = %log_path.display(),
+                "failed to create copilot log file, output will be discarded: {}", e
+            );
+            (Stdio::null(), Stdio::null())
+        }
+    };
+
     info!(
         cmd = copilot_cmd,
         prompt = %prompt_file.display(),
         dir = %work_dir.display(),
+        log = %log_path.display(),
         "spawning copilot (non-interactive, yolo)"
     );
 
@@ -53,8 +87,8 @@ pub async fn run_copilot(
         .arg("--yolo")
         .arg("--no-ask-user")
         .current_dir(work_dir)
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
+        .stdout(stdout_cfg)
+        .stderr(stderr_cfg)
         .stdin(Stdio::null())
         .spawn();
 
@@ -80,7 +114,36 @@ pub async fn run_copilot(
         Ok(())
     } else {
         let code = status.code().unwrap_or(-1);
-        error!(code, "copilot exited with non-zero status");
-        bail!("copilot exited with code {}", code)
+        error!(code, log = %log_path.display(), "copilot exited with non-zero status");
+
+        // Include the tail of the log file in the error for debugging.
+        let tail = read_tail(&log_path, 20);
+        bail!(
+            "copilot exited with code {} — see {}\n\n--- last lines ---\n{}",
+            code,
+            log_path.display(),
+            tail
+        )
     }
+}
+
+/// Read the last `n` lines from a file, returning them as a single string.
+/// Returns an empty string on any I/O error.
+fn read_tail(path: &Path, n: usize) -> String {
+    let Ok(mut file) = File::open(path) else {
+        return String::new();
+    };
+    let Ok(len) = file.seek(SeekFrom::End(0)) else {
+        return String::new();
+    };
+    // Read at most the last 8 KiB.
+    let read_from = len.saturating_sub(8192);
+    let _ = file.seek(SeekFrom::Start(read_from));
+    let mut buf = String::new();
+    if file.read_to_string(&mut buf).is_err() {
+        return String::new();
+    }
+    let lines: Vec<&str> = buf.lines().collect();
+    let start = lines.len().saturating_sub(n);
+    lines[start..].join("\n")
 }

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -267,23 +267,17 @@ impl Db {
         let mut stmt = conn
             .prepare("SELECT run_dir FROM pipelines")
             .context("failed to query active run_dirs")?;
-        let rows = stmt
-            .query_map([], |row| row.get::<_, String>(0))?;
-        for row in rows {
-            if let Ok(dir) = row {
-                set.insert(dir);
-            }
+        let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+        for dir in rows.flatten() {
+            set.insert(dir);
         }
 
         let mut stmt = conn
             .prepare("SELECT run_dir FROM completed")
             .context("failed to query completed run_dirs")?;
-        let rows = stmt
-            .query_map([], |row| row.get::<_, String>(0))?;
-        for row in rows {
-            if let Ok(dir) = row {
-                set.insert(dir);
-            }
+        let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+        for dir in rows.flatten() {
+            set.insert(dir);
         }
 
         Ok(set)

--- a/daemon/src/github.rs
+++ b/daemon/src/github.rs
@@ -244,12 +244,9 @@ pub async fn checkout_or_create_branch(worktree: &Path, branch: &str) -> Result<
         // Branch exists on remote — check it out. Use FETCH_HEAD which is
         // always valid after a successful fetch, even in shallow clones where
         // origin/<branch> may not resolve as a commit.
-        run_git(
-            &["checkout", "-b", branch, "FETCH_HEAD"],
-            worktree,
-        )
-        .await
-        .context("checkout_or_create_branch: failed to checkout existing remote branch")?;
+        run_git(&["checkout", "-b", branch, "FETCH_HEAD"], worktree)
+            .await
+            .context("checkout_or_create_branch: failed to checkout existing remote branch")?;
         tracing::info!("checked out existing remote branch: {}", branch);
     } else {
         // Branch does not exist on remote — create a new one.
@@ -319,12 +316,9 @@ pub async fn push_branch(worktree: &Path, branch: &str) -> Result<()> {
         "--force-with-lease rejected push for {}, retrying with --force",
         branch
     );
-    run_git(
-        &["push", "--force", "-u", "origin", branch],
-        worktree,
-    )
-    .await
-    .context("push_branch (force)")?;
+    run_git(&["push", "--force", "-u", "origin", branch], worktree)
+        .await
+        .context("push_branch (force)")?;
     Ok(())
 }
 
@@ -400,7 +394,12 @@ pub async fn delete_remote_branch(repo: &str, branch: &str) {
             tracing::info!(repo, branch, "deleted remote branch");
         }
         Err(e) => {
-            tracing::debug!(repo, branch, "could not delete remote branch (may already be gone): {:#}", e);
+            tracing::debug!(
+                repo,
+                branch,
+                "could not delete remote branch (may already be gone): {:#}",
+                e
+            );
         }
     }
 }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -160,6 +160,20 @@ fn run_status(runs_dir: &str) -> Result<()> {
 // `guild start` — main daemon with TUI
 // ---------------------------------------------------------------------------
 
+/// Generate a brief status description for the TUI based on the pipeline stage.
+fn stage_status_text(stage: &pipeline::Stage) -> String {
+    use pipeline::Stage;
+    match stage {
+        Stage::Plan | Stage::Implement | Stage::Verify | Stage::Fix => "copilot running…".into(),
+        Stage::Ingest => "fetching issue…".into(),
+        Stage::Understand => "analyzing…".into(),
+        Stage::Submit => "pushing PR…".into(),
+        Stage::Watch => "watching CI…".into(),
+        Stage::Done => "complete".into(),
+        Stage::Failed(_) => "failed".into(),
+    }
+}
+
 async fn run_start(config: Config, no_tui: bool) -> Result<()> {
     // --- ensure runs dir ---------------------------------------------------
     std::fs::create_dir_all(&config.runs_dir).with_context(|| {
@@ -358,6 +372,7 @@ async fn run_start(config: Config, no_tui: bool) -> Result<()> {
                     stage: p.stage.clone(),
                     branch_name: p.branch_name.clone(),
                     pr_number: p.pr_number,
+                    status_text: stage_status_text(&p.stage),
                 })
                 .collect(),
             last_poll: Some(now),
@@ -410,12 +425,14 @@ async fn run_start(config: Config, no_tui: bool) -> Result<()> {
                                 {
                                     snap.stage = pipeline.stage.clone();
                                     snap.pr_number = pipeline.pr_number;
+                                    snap.status_text = stage_status_text(&pipeline.stage);
                                 } else {
                                     current.pipelines.push(PipelineSnapshot {
                                         issue_number: pipeline.issue_number,
                                         stage: pipeline.stage.clone(),
                                         branch_name: pipeline.branch_name.clone(),
                                         pr_number: pipeline.pr_number,
+                                        status_text: stage_status_text(&pipeline.stage),
                                     });
                                 }
                                 let _ = state_tx_inner.send(current);
@@ -458,7 +475,8 @@ async fn run_start(config: Config, no_tui: bool) -> Result<()> {
                             error!(issue = key, "failed to complete pipeline: {:#}", e);
                         } else {
                             // Clean up local run directory and remote branch.
-                            github::delete_remote_branch(&pipeline.repo, &pipeline.branch_name).await;
+                            github::delete_remote_branch(&pipeline.repo, &pipeline.branch_name)
+                                .await;
                             pipeline.cleanup_run();
                         }
                     }
@@ -479,6 +497,7 @@ async fn run_start(config: Config, no_tui: bool) -> Result<()> {
                         stage: p.stage.clone(),
                         branch_name: p.branch_name.clone(),
                         pr_number: p.pr_number,
+                        status_text: stage_status_text(&p.stage),
                     })
                     .collect(),
                 last_poll: Some(chrono::Utc::now()),
@@ -519,7 +538,10 @@ fn cleanup_orphan_run_dirs(runs_dir: &std::path::Path, db: &db::Db) {
     let tracked = match db.all_tracked_run_dirs() {
         Ok(t) => t,
         Err(e) => {
-            error!("failed to query tracked run dirs, skipping orphan cleanup: {:#}", e);
+            error!(
+                "failed to query tracked run dirs, skipping orphan cleanup: {:#}",
+                e
+            );
             return;
         }
     };

--- a/daemon/src/pipeline.rs
+++ b/daemon/src/pipeline.rs
@@ -359,6 +359,7 @@ impl Pipeline {
             &config.model,
             &prompt_path,
             &self.worktree,
+            &self.run_dir,
         )
         .await
         .context("Plan: copilot run failed")?;
@@ -410,6 +411,7 @@ impl Pipeline {
             &config.model,
             &prompt_path,
             &self.worktree,
+            &self.run_dir,
         )
         .await
         .context("Implement: copilot run failed")?;
@@ -442,6 +444,7 @@ impl Pipeline {
             &config.model,
             &prompt_path,
             &self.worktree,
+            &self.run_dir,
         )
         .await
         .context("Verify: copilot run failed")?;
@@ -597,7 +600,10 @@ impl Pipeline {
         // If the PR was closed without merging, mark the pipeline as failed
         // so it stops polling but can be investigated.
         if pr_state == "CLOSED" {
-            info!("PR #{} was closed without merging. Marking failed.", pr_number);
+            info!(
+                "PR #{} was closed without merging. Marking failed.",
+                pr_number
+            );
             self.stage = Stage::Failed("PR closed without merging".to_string());
             return Ok(true);
         }
@@ -713,6 +719,7 @@ impl Pipeline {
             &config.model,
             &prompt_path,
             &self.worktree,
+            &self.run_dir,
         )
         .await
         .context("Fix: copilot run failed")?;

--- a/daemon/src/tui.rs
+++ b/daemon/src/tui.rs
@@ -34,6 +34,8 @@ pub struct PipelineSnapshot {
     pub stage: Stage,
     pub branch_name: String,
     pub pr_number: Option<u64>,
+    /// Brief status text shown in the TUI (e.g. "copilot running…").
+    pub status_text: String,
 }
 
 /// Full daemon state sent to the TUI on each cycle.
@@ -199,13 +201,15 @@ fn render_pipeline_table(
         return;
     }
 
-    let header_cells = ["#", "Stage", "Progress", "Branch", "PR"].iter().map(|h| {
-        Cell::from(*h).style(
-            Style::default()
-                .fg(Color::Yellow)
-                .add_modifier(Modifier::BOLD),
-        )
-    });
+    let header_cells = ["#", "Stage", "Progress", "Status", "Branch", "PR"]
+        .iter()
+        .map(|h| {
+            Cell::from(*h).style(
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            )
+        });
     let header = Row::new(header_cells).height(1);
 
     let visible_pipelines: Vec<_> = state.pipelines.iter().skip(scroll_offset).collect();
@@ -224,6 +228,7 @@ fn render_pipeline_table(
             Cell::from(format!("#{}", p.issue_number)).style(Style::default().fg(Color::White)),
             Cell::from(stage_name).style(Style::default().fg(stage_color)),
             Cell::from(progress_bar),
+            Cell::from(p.status_text.clone()).style(Style::default().fg(Color::DarkGray)),
             Cell::from(p.branch_name.clone()).style(Style::default().fg(Color::Blue)),
             Cell::from(pr_text).style(Style::default().fg(Color::Magenta)),
         ])
@@ -235,6 +240,7 @@ fn render_pipeline_table(
             Constraint::Length(8),
             Constraint::Length(14),
             Constraint::Length(22),
+            Constraint::Length(20),
             Constraint::Min(20),
             Constraint::Length(8),
         ],


### PR DESCRIPTION
Closes #13

## Problem

The terminal interface breaks when work starts for a task. 

The work being made by the agent for a specific task should not log to terminal main interface. It breaks the initial overview.

---
*Generated by [guild](https://github.com/KaugaKauga/guild)*