### PR TITLE
guild: padding between progress bars (#23)

### DIFF
--- a/daemon/src/tui.rs
+++ b/daemon/src/tui.rs
@@ -265,7 +265,7 @@ fn render_pipeline_table(
             Cell::from(p.status_text.clone()).style(Style::default().fg(Color::DarkGray)),
             Cell::from(p.branch_name.clone()).style(Style::default().fg(Color::Blue)),
             Cell::from(pr_text).style(Style::default().fg(Color::Magenta)),
-        ])
+        ]).bottom_margin(1)
     });
 
     let table = Table::new(


### PR DESCRIPTION
Closes #23

## Problem

With multiple tasks  running at the same time, the lack of padding/margin makes adjacent progress bars touch each other. Add some padding or margin to the rows.

---
*Generated by [guild](https://github.com/KaugaKauga/guild)*