### PR TITLE
guild: Run tests on CI (#29)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: daemon
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: daemon
+      - run: cargo test


### PR DESCRIPTION
Closes #29

## Problem

The repository has existing tests but no CI pipeline to run them automatically. PRs can be merged to main without any test validation.

## Solution

Added `.github/workflows/ci.yml` — a GitHub Actions workflow that runs `cargo test` in the `daemon/` directory on every pull request targeting `main`. Uses `dtolnay/rust-toolchain@stable` for Rust setup and `Swatinem/rust-cache@v2` for dependency caching.


---
*Generated by [guild](https://github.com/KaugaKauga/guild)*