### PR TITLE
guild: Add eyes emoji to ack message (#43)

### DIFF
--- a/daemon/src/github.rs
+++ b/daemon/src/github.rs
@@ -19,6 +19,9 @@ pub struct Issue {
     pub labels: Vec<Label>,
     #[serde(default)]
     pub comments: Vec<Comment>,
+    /// GraphQL node ID, used for adding reactions.
+    #[serde(default)]
+    pub id: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -28,6 +31,9 @@ pub struct Label {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Comment {
+    /// GraphQL node ID, used for adding reactions.
+    #[serde(default)]
+    pub id: Option<String>,
     pub author: CommentAuthor,
     pub body: String,
     #[serde(rename = "createdAt")]
@@ -41,6 +47,9 @@ pub struct CommentAuthor {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PrComment {
+    /// GraphQL node ID, used for adding reactions.
+    #[serde(default)]
+    pub id: Option<String>,
     pub author: CommentAuthor,
     pub body: String,
     #[serde(rename = "createdAt")]
@@ -187,7 +196,7 @@ pub async fn fetch_issue_detail(repo: &str, number: u64) -> Result<Issue> {
         "--repo",
         repo,
         "--json",
-        "number,title,body,state,labels,comments",
+        "id,number,title,body,state,labels,comments",
     ])
     .await
     .context("fetch_issue_detail")?;
@@ -520,6 +529,30 @@ pub async fn fetch_failed_check_logs(
     results
 }
 
+/// Add the 👀 (eyes) reaction to a GitHub comment or issue by its node ID.
+/// This is best-effort: failures are logged but not propagated.
+pub async fn react_with_eyes(node_id: &str) {
+    let query = format!(
+        r#"mutation {{ addReaction(input: {{subjectId: "{}", content: EYES}}) {{ reaction {{ content }} }} }}"#,
+        node_id
+    );
+    let result = run_gh(&["api", "graphql", "-f", &format!("query={}", query)]).await;
+    match result {
+        Ok(_) => tracing::info!(node_id, "added 👀 reaction"),
+        Err(e) => tracing::debug!(node_id, "failed to add 👀 reaction (best-effort): {:#}", e),
+    }
+}
+
+/// Build the GraphQL mutation query string for adding an eyes reaction.
+/// Exposed for testing.
+#[cfg(test)]
+fn build_eyes_reaction_query(node_id: &str) -> String {
+    format!(
+        r#"mutation {{ addReaction(input: {{subjectId: "{}", content: EYES}}) {{ reaction {{ content }} }} }}"#,
+        node_id
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -574,5 +607,44 @@ mod tests {
         assert!(log.len() > MAX_LOG_BYTES);
         let result = truncate_log(&log);
         assert!(result.len() <= MAX_LOG_BYTES + 20); // +20 for the truncation prefix
+    }
+
+    #[test]
+    fn test_build_eyes_reaction_query() {
+        let query = build_eyes_reaction_query("IC_kwDOTest123");
+        assert!(query.contains("IC_kwDOTest123"));
+        assert!(query.contains("addReaction"));
+        assert!(query.contains("EYES"));
+        assert!(query.contains("subjectId"));
+    }
+
+    #[test]
+    fn test_comment_deserializes_with_id() {
+        let json = r#"{"id":"IC_kwDOTest","author":{"login":"user"},"body":"hello","createdAt":"2025-01-01T00:00:00Z"}"#;
+        let comment: Comment = serde_json::from_str(json).unwrap();
+        assert_eq!(comment.id.as_deref(), Some("IC_kwDOTest"));
+    }
+
+    #[test]
+    fn test_comment_deserializes_without_id() {
+        let json =
+            r#"{"author":{"login":"user"},"body":"hello","createdAt":"2025-01-01T00:00:00Z"}"#;
+        let comment: Comment = serde_json::from_str(json).unwrap();
+        assert!(comment.id.is_none());
+    }
+
+    #[test]
+    fn test_issue_deserializes_with_node_id() {
+        let json = r#"{"id":"I_kwDOTest","number":1,"title":"t","body":"b","state":"OPEN","labels":[],"comments":[]}"#;
+        let issue: Issue = serde_json::from_str(json).unwrap();
+        assert_eq!(issue.id.as_deref(), Some("I_kwDOTest"));
+    }
+
+    #[test]
+    fn test_issue_deserializes_without_node_id() {
+        let json =
+            r#"{"number":1,"title":"t","body":"b","state":"OPEN","labels":[],"comments":[]}"#;
+        let issue: Issue = serde_json::from_str(json).unwrap();
+        assert!(issue.id.is_none());
     }
 }

--- a/daemon/src/pipeline.rs
+++ b/daemon/src/pipeline.rs
@@ -233,6 +233,11 @@ impl Pipeline {
             .await
             .context("Ingest: failed to fetch issue detail")?;
 
+        // React with 👀 to acknowledge the issue is being worked on.
+        if let Some(ref node_id) = issue.id {
+            github::react_with_eyes(node_id).await;
+        }
+
         // Persist the full issue JSON.
         let issue_json =
             serde_json::to_string_pretty(&issue).context("Ingest: failed to serialise issue")?;
@@ -551,6 +556,13 @@ impl Pipeline {
                 is_human && c.body.contains("@guild")
             })
             .collect();
+
+        // React with 👀 on each @guild comment to acknowledge it.
+        for c in &guild_comments {
+            if let Some(ref node_id) = c.id {
+                github::react_with_eyes(node_id).await;
+            }
+        }
 
         // Collect formal review bodies when changes are requested.
         let review_comments: Vec<&github::Review> = if status.review_decision == "CHANGES_REQUESTED"


### PR DESCRIPTION
Closes #43

## Problem

When a user mentions `@guild` in a comment or creates a guild-labeled issue, there's no visual indication that the request has been acknowledged. Users are left guessing whether guild has picked up their request.

## Solution

Guild now reacts with the 👀 (eyes) emoji on issues and PR comments it picks up, providing immediate visual feedback.

**Changes:**

- **`github.rs`**: Added `id: Option<String>` (GraphQL node ID) to `Issue`, `Comment`, and `PrComment` structs. Added `react_with_eyes()` function that uses the GraphQL `addReaction` mutation via `gh api graphql`. Updated `fetch_issue_detail` to request the `id` field. Added tests for deserialization with/without IDs and query construction.
- **`pipeline.rs`**: In `do_ingest()`, reacts with 👀 on the issue after fetching its detail. In `do_watch()`, reacts with 👀 on each `@guild`-mentioning PR comment before processing.

Reactions are best-effort — failures are logged but don't block the pipeline. GitHub's API handles deduplication automatically.


---
*Generated by [guild](https://github.com/KaugaKauga/guild)*