### PR TITLE
guild: Screen flicker (#44)

### DIFF
--- a/daemon/Cargo.lock
+++ b/daemon/Cargo.lock
@@ -255,6 +255,7 @@ checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
+ "futures-core",
  "mio",
  "parking_lot",
  "rustix",
@@ -373,6 +374,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,6 +479,7 @@ dependencies = [
  "chrono",
  "clap",
  "crossterm",
+ "futures",
  "hex",
  "libc",
  "ratatui",
@@ -886,6 +976,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -16,5 +16,6 @@ sha2 = "0.10"
 hex = "0.4"
 rusqlite = { version = "0.31", features = ["bundled"] }
 ratatui = "0.29"
-crossterm = "0.28"
+crossterm = { version = "0.28", features = ["event-stream"] }
+futures = "0.3"
 libc = "0.2"

--- a/daemon/src/tui.rs
+++ b/daemon/src/tui.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use crossterm::event::{Event, EventStream, KeyCode, KeyEventKind};
 use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
 };
@@ -20,6 +20,8 @@ use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table};
 use ratatui::Terminal;
+
+use futures::StreamExt;
 
 use crate::pipeline::Stage;
 
@@ -86,71 +88,153 @@ pub async fn run_tui(
     result
 }
 
+/// Returns true if any pipeline is in an active (non-terminal) stage.
+pub fn has_active_pipelines(state: &DaemonState) -> bool {
+    state
+        .pipelines
+        .iter()
+        .any(|p| !matches!(p.stage, Stage::Done | Stage::Failed(_)))
+}
+
+/// Compute the "last poll" display text, returning the seconds value for caching.
+pub fn format_last_poll(last_poll: Option<chrono::DateTime<chrono::Utc>>) -> (Option<i64>, String) {
+    match last_poll {
+        Some(t) => {
+            let secs = chrono::Utc::now().signed_duration_since(t).num_seconds();
+            (Some(secs), format!("last poll: {}s ago", secs))
+        }
+        None => (None, "last poll: —".to_string()),
+    }
+}
+
 async fn render_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
-    state_rx: tokio::sync::watch::Receiver<DaemonState>,
+    mut state_rx: tokio::sync::watch::Receiver<DaemonState>,
     shutdown: &Arc<AtomicBool>,
 ) -> io::Result<()> {
     let mut scroll_offset: usize = 0;
     let mut tick: usize = 0;
+    let mut event_stream = EventStream::new();
+    let mut spinner_interval = tokio::time::interval(Duration::from_millis(200));
+
+    // Cache for the "last poll: Xs ago" text to avoid per-frame diffs
+    let mut cached_poll_secs: Option<i64>;
+    let mut cached_poll_text: String;
 
     // Clear once at startup so we begin with a clean slate.
     // Ratatui's draw() uses double-buffer diffing after this point,
     // so per-frame clears are unnecessary and cause flicker.
     terminal.clear()?;
 
+    // Draw initial frame
+    {
+        let state = state_rx.borrow().clone();
+        let (secs, text) = format_last_poll(state.last_poll);
+        cached_poll_secs = secs;
+        cached_poll_text = text;
+        draw_frame(terminal, &state, scroll_offset, tick, &cached_poll_text)?;
+    }
+
     loop {
         if shutdown.load(Ordering::SeqCst) {
             break;
         }
 
-        let state = state_rx.borrow().clone();
+        let mut needs_redraw = false;
 
-        terminal.draw(|frame| {
-            let area = frame.area();
-
-            // Layout: header (3) | table (stretch) | footer (3)
-            let chunks = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([
-                    Constraint::Length(3),
-                    Constraint::Min(5),
-                    Constraint::Length(3),
-                ])
-                .split(area);
-
-            render_header(frame, chunks[0], &state);
-            render_pipeline_table(frame, chunks[1], &state, scroll_offset, tick);
-            render_footer(frame, chunks[2], &state);
-        })?;
-
-        tick = tick.wrapping_add(1);
-
-        // Poll for keyboard events (non-blocking with timeout)
-        if event::poll(Duration::from_millis(250))? {
-            if let Event::Key(key) = event::read()? {
-                if key.kind == KeyEventKind::Press {
-                    match key.code {
-                        KeyCode::Char('q') | KeyCode::Esc => {
-                            shutdown.store(true, Ordering::SeqCst);
-                            break;
-                        }
-                        KeyCode::Up | KeyCode::Char('k') => {
-                            scroll_offset = scroll_offset.saturating_sub(1);
-                        }
-                        KeyCode::Down | KeyCode::Char('j') => {
-                            let max = state_rx.borrow().pipelines.len().saturating_sub(1);
-                            if scroll_offset < max {
-                                scroll_offset += 1;
+        tokio::select! {
+            result = state_rx.changed() => {
+                if result.is_ok() {
+                    needs_redraw = true;
+                    // Update cached poll text if seconds changed
+                    let state = state_rx.borrow();
+                    let (secs, text) = format_last_poll(state.last_poll);
+                    if cached_poll_secs != secs {
+                        cached_poll_secs = secs;
+                        cached_poll_text = text;
+                    }
+                }
+            }
+            maybe_event = event_stream.next() => {
+                if let Some(Ok(event)) = maybe_event {
+                    match event {
+                        Event::Key(key) if key.kind == KeyEventKind::Press => {
+                            match key.code {
+                                KeyCode::Char('q') | KeyCode::Esc => {
+                                    shutdown.store(true, Ordering::SeqCst);
+                                    break;
+                                }
+                                KeyCode::Up | KeyCode::Char('k') => {
+                                    scroll_offset = scroll_offset.saturating_sub(1);
+                                    needs_redraw = true;
+                                }
+                                KeyCode::Down | KeyCode::Char('j') => {
+                                    let max = state_rx.borrow()
+                                        .pipelines.len().saturating_sub(1);
+                                    if scroll_offset < max {
+                                        scroll_offset += 1;
+                                    }
+                                    needs_redraw = true;
+                                }
+                                _ => {}
                             }
+                        }
+                        Event::Resize(_, _) => {
+                            needs_redraw = true;
                         }
                         _ => {}
                     }
                 }
             }
+            _ = spinner_interval.tick() => {
+                tick = tick.wrapping_add(1);
+                // Only redraw for spinner if there are active pipelines
+                let state = state_rx.borrow();
+                if has_active_pipelines(&state) {
+                    needs_redraw = true;
+                }
+                // Update poll text periodically
+                let (secs, text) = format_last_poll(state.last_poll);
+                if cached_poll_secs != secs {
+                    cached_poll_secs = secs;
+                    cached_poll_text = text;
+                    needs_redraw = true;
+                }
+            }
+        }
+
+        if needs_redraw {
+            let state = state_rx.borrow().clone();
+            draw_frame(terminal, &state, scroll_offset, tick, &cached_poll_text)?;
         }
     }
 
+    Ok(())
+}
+
+fn draw_frame(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    state: &DaemonState,
+    scroll_offset: usize,
+    tick: usize,
+    last_poll_text: &str,
+) -> io::Result<()> {
+    terminal.draw(|frame| {
+        let area = frame.area();
+
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(3),
+                Constraint::Min(5),
+                Constraint::Length(3),
+            ])
+            .split(area);
+
+        render_header(frame, chunks[0], state);
+        render_pipeline_table(frame, chunks[1], state, scroll_offset, tick);
+        render_footer(frame, chunks[2], state, last_poll_text);
+    })?;
     Ok(())
 }
 
@@ -301,15 +385,12 @@ fn render_pipeline_table(
     frame.render_widget(table, area);
 }
 
-fn render_footer(frame: &mut ratatui::Frame, area: Rect, state: &DaemonState) {
-    let last_poll_text = match state.last_poll {
-        Some(t) => {
-            let elapsed = chrono::Utc::now().signed_duration_since(t);
-            format!("last poll: {}s ago", elapsed.num_seconds())
-        }
-        None => "last poll: —".to_string(),
-    };
-
+fn render_footer(
+    frame: &mut ratatui::Frame,
+    area: Rect,
+    state: &DaemonState,
+    last_poll_text: &str,
+) {
     let active_count = state
         .pipelines
         .iter()
@@ -439,5 +520,67 @@ mod tests {
         assert!(bar.contains("3/8"));
         assert!(bar.contains("███"));
         assert!(bar.contains("░░░░░"));
+    }
+
+    #[test]
+    fn cached_poll_text_format_none() {
+        let (secs, text) = format_last_poll(None);
+        assert_eq!(secs, None);
+        assert_eq!(text, "last poll: —");
+    }
+
+    #[test]
+    fn cached_poll_text_format_some() {
+        let past = chrono::Utc::now() - chrono::Duration::seconds(5);
+        let (secs, text) = format_last_poll(Some(past));
+        // Should be approximately 5 seconds (allow for test execution time)
+        assert!(secs.unwrap() >= 4 && secs.unwrap() <= 6);
+        assert!(text.starts_with("last poll: "));
+        assert!(text.ends_with("s ago"));
+    }
+
+    #[test]
+    fn no_redraw_when_no_active_pipelines() {
+        let empty_state = DaemonState::default();
+        assert!(!has_active_pipelines(&empty_state));
+
+        let done_state = DaemonState {
+            pipelines: vec![
+                PipelineSnapshot {
+                    issue_number: 1,
+                    issue_title: "test".into(),
+                    stage: Stage::Done,
+                    branch_name: "b".into(),
+                    pr_number: None,
+                    status_text: "done".into(),
+                },
+                PipelineSnapshot {
+                    issue_number: 2,
+                    issue_title: "test2".into(),
+                    stage: Stage::Failed("err".into()),
+                    branch_name: "b2".into(),
+                    pr_number: None,
+                    status_text: "failed".into(),
+                },
+            ],
+            ..Default::default()
+        };
+        assert!(!has_active_pipelines(&done_state));
+    }
+
+    #[test]
+    fn redraw_when_active_pipelines_exist() {
+        let active_state = DaemonState {
+            pipelines: vec![PipelineSnapshot {
+                issue_number: 1,
+                issue_title: "test".into(),
+                stage: Stage::Implement,
+                branch_name: "b".into(),
+                pr_number: None,
+                status_text: "running".into(),
+            }],
+            ..Default::default()
+        };
+        assert!(has_active_pipelines(&active_state));
     }
 }


### PR DESCRIPTION
Closes #44

## Problem

The TUI flickers constantly because the render loop uses synchronous `event::poll()` which blocks the tokio runtime for 250ms per iteration, and redraws unconditionally every tick — even when nothing has changed. The footer's "last poll: Xs ago" text and the spinner both change every frame, causing ratatui's diff algorithm to always detect changes and emit terminal escape sequences.

## Solution

Replaced the blocking poll-loop with an async `tokio::select!`-based event loop using crossterm's `EventStream` (via the `event-stream` feature). The loop now has three branches — state changes from the watch channel, keyboard/resize events from `EventStream`, and a 200ms spinner interval — each setting a `needs_redraw` flag. Frames are only drawn when something actually changed. The spinner tick only triggers redraws when active pipelines exist, and the "last poll" footer text is cached so it only updates when the seconds value changes. Extracted `draw_frame`, `has_active_pipelines`, and `format_last_poll` as helper functions with corresponding tests.


---
*Generated by [guild](https://github.com/KaugaKauga/guild)*