### PR TITLE
guild: Use git worktree (#20)

### DIFF
--- a/.guild/learnings.md
+++ b/.guild/learnings.md
@@ -1,0 +1,4 @@
+- The `Pipeline` struct is serialized/deserialized with serde for both JSON (state.json migration) and SQLite persistence — any new field needs a default value or the migration path will fail for existing databases.
+- Git worktree `.git` is a file (not a directory) pointing to the main repo's `.git/worktrees/<name>/` — lock files like `index.lock` live there, not at `worktree/.git/index.lock`. Use `git rev-parse --git-dir` to resolve it.
+- The `cleanup_run()` method on Pipeline is `#[allow(dead_code)]` — actual cleanup happens in the orchestrator loop in `main.rs` via a spawned tokio task, not through this method.
+- `db.rs` migrations use `PRAGMA table_info` to detect missing columns and `ALTER TABLE` to add them — new columns must have a `DEFAULT` clause to work with existing rows.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ INGEST ─▶ UNDERSTAND ─▶ PLAN ─▶ IMPLEMENT ─▶ VERIFY ─▶ SUBMI
 | Stage | Who runs it | What happens |
 |-------|-------------|--------------|
 | **INGEST** | Daemon | Fetches the issue body, metadata, comments, and linked issues via `gh`. Saves everything as JSON + markdown into the run directory. |
-| **UNDERSTAND** | Daemon | Shallow-clones the repo. Scans for CI workflows, contributing docs, dependency manifests. Reads `.guild/learnings.md` for repo-specific agent knowledge. Builds a directory tree. Creates a working branch (`guild/issue-{N}`). |
+| **UNDERSTAND** | Daemon | Ensures a shared bare clone of the repo exists (or fetches updates). Creates a git worktree with the working branch (`guild/issue-{N}`). Scans for CI workflows, contributing docs, dependency manifests. Reads `.guild/learnings.md` for repo-specific agent knowledge. Builds a directory tree. |
 | **PLAN** | Copilot | Reads the issue + repo summary. Produces `plan.md` — which files to touch, what tests to write, what UI wiring is needed. |
 | **IMPLEMENT** | Copilot | Writes production code and tests following the plan. Wires changes into the UI so they're actually reachable, not just isolated files. Appends any repo-specific learnings to `.guild/learnings.md`. |
 | **VERIFY** | Copilot | Runs linting and basic checks. Fixes lint errors. Does **not** run full test suites that might hang (watch mode, browser tests). Trusts CI for that. |
@@ -118,6 +118,7 @@ Comments without `@guild` are left alone.
 | `--poll-interval` / `-p` | `30` | Seconds between polling cycles |
 | `--copilot-cmd` | `copilot` | Path or name of the Copilot CLI binary |
 | `--runs-dir` | `./runs` | Where run artifacts and worktrees are stored |
+| `--repos-dir` | `./repos` | Where shared bare clones are stored (one per repo) |
 
 ## Architecture
 
@@ -136,6 +137,8 @@ guild/
     implement.md
     verify.md
     fix.md
+  repos/                      # Shared bare clones (one per repo, gitignored)
+    owner-repo.git/           # Bare clone — shared object store
   runs/                       # Per-run artifacts (gitignored)
     guild.db                  # SQLite database (pipelines + completed ledger)
     {timestamp}-{repo}-{issue}/
@@ -148,7 +151,7 @@ guild/
       blocker_report.md       # What's blocking the PR
       learnings.md            # Repo-specific learnings (copied from worktree)
       prompt_*.md             # Generated prompts for each stage
-      worktree/               # Shallow clone of the repo (working branch)
+      worktree/               # Git worktree (shares object store with bare clone)
 ```
 
 ### State persistence

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -41,6 +41,7 @@ impl Db {
                 stage               TEXT NOT NULL,
                 run_dir             TEXT NOT NULL,
                 worktree            TEXT NOT NULL,
+                bare_repo           TEXT NOT NULL DEFAULT '',
                 pr_number           INTEGER,
                 blocker_fingerprint TEXT,
                 branch_name         TEXT NOT NULL,
@@ -58,17 +59,18 @@ impl Db {
         .context("failed to create database tables")?;
 
         // --- Schema migrations ------------------------------------------------
-        // CREATE TABLE IF NOT EXISTS won't alter an existing table, so we must
-        // check for columns that were added after the initial schema and add
-        // them with ALTER TABLE if missing.
         Self::migrate_add_column(
             &conn,
             "pipelines",
             "issue_title",
             "TEXT NOT NULL DEFAULT ''",
         )?;
-        // Add future column migrations here following the same pattern.
-        // ----------------------------------------------------------------------
+        Self::migrate_add_column(
+            &conn,
+            "pipelines",
+            "bare_repo",
+            "TEXT NOT NULL DEFAULT ''",
+        )?;
 
         info!(path = %path.display(), "database opened");
 
@@ -114,7 +116,8 @@ impl Db {
         let mut stmt = conn
             .prepare(
                 "SELECT issue_number, repo, stage, run_dir, worktree,
-                        pr_number, blocker_fingerprint, branch_name, issue_title
+                        pr_number, blocker_fingerprint, branch_name, issue_title,
+                        bare_repo
                  FROM   pipelines",
             )
             .context("failed to prepare pipeline query")?;
@@ -140,6 +143,7 @@ impl Db {
                     blocker_fingerprint: row.get(6)?,
                     branch_name: row.get(7)?,
                     issue_title: row.get::<_, Option<String>>(8)?.unwrap_or_default(),
+                    bare_repo: PathBuf::from(row.get::<_, Option<String>>(9)?.unwrap_or_default()),
                 })
             })
             .context("failed to query pipelines")?;
@@ -187,8 +191,9 @@ impl Db {
         conn.execute(
             "INSERT INTO pipelines
                 (issue_number, repo, stage, run_dir, worktree,
-                 pr_number, blocker_fingerprint, branch_name, issue_title)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+                 pr_number, blocker_fingerprint, branch_name, issue_title,
+                 bare_repo)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
              ON CONFLICT(issue_number) DO UPDATE SET
                 stage               = excluded.stage,
                 run_dir             = excluded.run_dir,
@@ -196,7 +201,8 @@ impl Db {
                 pr_number           = excluded.pr_number,
                 blocker_fingerprint = excluded.blocker_fingerprint,
                 branch_name         = excluded.branch_name,
-                issue_title         = excluded.issue_title",
+                issue_title         = excluded.issue_title,
+                bare_repo           = excluded.bare_repo",
             params![
                 p.issue_number,
                 p.repo,
@@ -207,6 +213,7 @@ impl Db {
                 p.blocker_fingerprint,
                 p.branch_name,
                 p.issue_title,
+                p.bare_repo.to_string_lossy().as_ref(),
             ],
         )
         .context("failed to upsert pipeline")?;
@@ -338,8 +345,9 @@ impl Db {
                 tx.execute(
                     "INSERT OR IGNORE INTO pipelines
                         (issue_number, repo, stage, run_dir, worktree,
-                         pr_number, blocker_fingerprint, branch_name, issue_title)
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                         pr_number, blocker_fingerprint, branch_name, issue_title,
+                         bare_repo)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
                     params![
                         p.issue_number,
                         p.repo,
@@ -350,6 +358,7 @@ impl Db {
                         p.blocker_fingerprint,
                         p.branch_name,
                         p.issue_title,
+                        p.bare_repo.to_string_lossy().as_ref(),
                     ],
                 )
                 .context("failed to migrate active pipeline")?;

--- a/daemon/src/github.rs
+++ b/daemon/src/github.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
 use anyhow::{bail, Context, Result};
@@ -205,75 +205,121 @@ pub async fn fetch_issue_detail(repo: &str, number: u64) -> Result<Issue> {
     Ok(issue)
 }
 
-/// Shallow-clone  into .
-pub async fn clone_repo(repo: &str, dest: &Path) -> Result<()> {
-    let dest_str = dest
+/// Ensure a bare clone of `repo` exists at `repos_dir/<owner>-<repo>.git`.
+///
+/// If the bare repo already exists, runs `git fetch --prune origin` to update
+/// it. Otherwise, creates it with `gh repo clone ... -- --bare`.
+/// Returns the path to the bare repo directory.
+pub async fn ensure_bare_repo(repo: &str, repos_dir: &Path) -> Result<PathBuf> {
+    let bare_name = format!("{}.git", repo.replace('/', "-"));
+    let bare_path = repos_dir.join(&bare_name);
+    let bare_str = bare_path
         .to_str()
-        .context("clone_repo: destination path is not valid UTF-8")?;
+        .context("ensure_bare_repo: bare repo path is not valid UTF-8")?
+        .to_string();
 
-    run_gh(&[
-        "repo",
-        "clone",
-        repo,
-        dest_str,
-        "--",
-        "--depth=1",
-        "--single-branch",
-    ])
-    .await
-    .context("clone_repo")?;
+    if bare_path.exists() {
+        // Already cloned — fetch latest refs.
+        tracing::info!(path = %bare_path.display(), "bare repo exists, fetching updates");
+        if let Err(e) = run_git(&["fetch", "--prune", "origin"], &bare_path).await {
+            tracing::warn!("bare repo fetch failed (will continue): {:#}", e);
+        }
+    } else {
+        // Clone as bare.
+        tracing::info!(repo, path = %bare_path.display(), "cloning bare repo");
+        run_gh(&["repo", "clone", repo, &bare_str, "--", "--bare"])
+            .await
+            .context("ensure_bare_repo: failed to clone bare repo")?;
+    }
+
+    Ok(bare_path)
+}
+
+/// Create a git worktree at `worktree_dest` with branch `branch`.
+///
+/// If the branch already exists on origin, the worktree is based on
+/// `origin/<branch>` (using `-B` to reset it). Otherwise, a new branch is
+/// created from HEAD (the default branch).
+pub async fn add_worktree(bare_repo: &Path, worktree_dest: &Path, branch: &str) -> Result<()> {
+    let dest_str = worktree_dest
+        .to_str()
+        .context("add_worktree: worktree path is not valid UTF-8")?;
+
+    // Check if the branch exists on origin.
+    let remote_ref = format!("origin/{}", branch);
+    let branch_on_remote = run_git(&["rev-parse", "--verify", &remote_ref], bare_repo)
+        .await
+        .is_ok();
+
+    if branch_on_remote {
+        // Branch exists on remote — base worktree on it (reset with -B).
+        run_git(
+            &["worktree", "add", dest_str, "-B", branch, &remote_ref],
+            bare_repo,
+        )
+        .await
+        .context("add_worktree: failed to add worktree from remote branch")?;
+        tracing::info!(branch, "worktree created from existing remote branch");
+    } else {
+        // New branch — create from HEAD (default branch).
+        run_git(&["worktree", "add", dest_str, "-b", branch], bare_repo)
+            .await
+            .context("add_worktree: failed to add worktree with new branch")?;
+        tracing::info!(branch, "worktree created with new branch");
+    }
+
+    // Configure user identity in the worktree so commits work.
+    let _ = run_git(
+        &["config", "user.email", "guild@users.noreply.github.com"],
+        worktree_dest,
+    )
+    .await;
+    let _ = run_git(&["config", "user.name", "Guild"], worktree_dest).await;
 
     Ok(())
 }
 
-/// Check out an existing remote branch, or create a new local branch if it
-/// does not exist on the remote.
-///
-/// This avoids the situation where a fresh shallow clone tries to create a
-/// branch that already exists on origin, which would later cause a push
-/// rejection.
-pub async fn checkout_or_create_branch(worktree: &Path, branch: &str) -> Result<()> {
-    // 1. Check if we are already on the target branch.
-    if let Ok(current) = run_git(&["rev-parse", "--abbrev-ref", "HEAD"], worktree).await {
-        if current.trim() == branch {
-            tracing::info!("already on branch: {}", branch);
-            return Ok(());
+/// Remove a git worktree. Falls back to `fs::remove_dir_all` + `git worktree
+/// prune` if the git command fails.
+pub async fn remove_worktree(bare_repo: &Path, worktree_dest: &Path) -> Result<()> {
+    let dest_str = worktree_dest
+        .to_str()
+        .context("remove_worktree: worktree path is not valid UTF-8")?;
+
+    let result = run_git(&["worktree", "remove", "--force", dest_str], bare_repo).await;
+
+    if result.is_err() {
+        tracing::warn!(
+            path = %worktree_dest.display(),
+            "git worktree remove failed, falling back to rm + prune"
+        );
+        if worktree_dest.exists() {
+            std::fs::remove_dir_all(worktree_dest)
+                .with_context(|| format!("failed to remove worktree at {}", worktree_dest.display()))?;
         }
+        let _ = run_git(&["worktree", "prune"], bare_repo).await;
     }
 
-    // 2. Check if the branch exists locally.
-    let ref_spec = format!("refs/heads/{}", branch);
-    if run_git(&["rev-parse", "--verify", &ref_spec], worktree)
-        .await
-        .is_ok()
-    {
-        run_git(&["checkout", branch], worktree)
-            .await
-            .context("checkout_or_create_branch: failed to checkout existing local branch")?;
-        tracing::info!("checked out existing local branch: {}", branch);
-        return Ok(());
-    }
-
-    // 3. Try to fetch from origin (with depth=1 to handle shallow clones).
-    let fetch_result = run_git(&["fetch", "--depth=1", "origin", branch], worktree).await;
-
-    if fetch_result.is_ok() {
-        // Branch exists on remote — check it out. Use FETCH_HEAD which is
-        // always valid after a successful fetch, even in shallow clones where
-        // origin/<branch> may not resolve as a commit.
-        run_git(&["checkout", "-b", branch, "FETCH_HEAD"], worktree)
-            .await
-            .context("checkout_or_create_branch: failed to checkout existing remote branch")?;
-        tracing::info!("checked out existing remote branch: {}", branch);
-    } else {
-        // Branch does not exist on remote — create a new one.
-        run_git(&["checkout", "-b", branch], worktree)
-            .await
-            .context("checkout_or_create_branch: failed to create new branch")?;
-        tracing::info!("created new branch: {}", branch);
-    }
-
+    tracing::info!(path = %worktree_dest.display(), "worktree removed");
     Ok(())
+}
+
+/// Resolve the actual `.git` directory for a worktree path.
+///
+/// In a worktree layout, `.git` is a file that points to the main repo's
+/// `.git/worktrees/<name>/` directory. This helper returns the actual git dir
+/// so lock files can be found correctly.
+pub async fn resolve_git_dir(worktree: &Path) -> Result<PathBuf> {
+    let output = run_git(&["rev-parse", "--git-dir"], worktree)
+        .await
+        .context("resolve_git_dir")?;
+    let git_dir = output.trim();
+    let path = std::path::Path::new(git_dir);
+    if path.is_absolute() {
+        Ok(path.to_path_buf())
+    } else {
+        Ok(worktree.join(path))
+    }
 }
 
 /// Stage everything and commit with the given message.
@@ -308,17 +354,13 @@ pub async fn commit_all(worktree: &Path, message: &str) -> Result<()> {
     Ok(())
 }
 
-/// Push  to origin, setting upstream tracking.
+/// Push `branch` to origin, setting upstream tracking.
 ///
-/// Fetches the remote branch first so that `--force-with-lease` has accurate
-/// tracking info (shallow clones and FETCH_HEAD checkouts often leave it stale).
+/// Tries `--force-with-lease` first (safe default). Falls back to `--force`
+/// if tracking info is stale. Safe because guild owns these branches exclusively.
 pub async fn push_branch(worktree: &Path, branch: &str) -> Result<()> {
     // Refresh remote tracking info so --force-with-lease has accurate state.
     let _ = run_git(&["fetch", "origin", branch], worktree).await;
-
-    // Try --force-with-lease first (safe default). If it fails due to stale
-    // tracking info (common with shallow clones), fall back to --force.
-    // This is safe because guild owns these branches exclusively.
     let result = run_git(
         &["push", "--force-with-lease", "-u", "origin", branch],
         worktree,
@@ -646,5 +688,20 @@ mod tests {
             r#"{"number":1,"title":"t","body":"b","state":"OPEN","labels":[],"comments":[]}"#;
         let issue: Issue = serde_json::from_str(json).unwrap();
         assert!(issue.id.is_none());
+    }
+
+    #[test]
+    fn test_bare_repo_name_computation() {
+        // Verify the naming convention used by ensure_bare_repo.
+        let repo = "owner/repo";
+        let bare_name = format!("{}.git", repo.replace('/', "-"));
+        assert_eq!(bare_name, "owner-repo.git");
+    }
+
+    #[test]
+    fn test_bare_repo_name_with_org() {
+        let repo = "my-org/my-repo";
+        let bare_name = format!("{}.git", repo.replace('/', "-"));
+        assert_eq!(bare_name, "my-org-my-repo.git");
     }
 }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -59,6 +59,10 @@ enum Commands {
         #[arg(long, default_value = "./runs")]
         runs_dir: String,
 
+        /// Directory for shared bare clones (one per repo)
+        #[arg(long, default_value = "./repos")]
+        repos_dir: String,
+
         /// Maximum number of pipelines to advance concurrently
         #[arg(short = 'c', long, default_value_t = 5)]
         max_concurrent: usize,
@@ -89,6 +93,7 @@ pub struct Config {
     pub copilot_cmd: String,
     pub model: String,
     pub runs_dir: PathBuf,
+    pub repos_dir: PathBuf,
     pub max_concurrent: usize,
     pub agents_dir: PathBuf,
 }
@@ -106,6 +111,7 @@ async fn main() -> Result<()> {
             copilot_cmd,
             model,
             runs_dir,
+            repos_dir,
             max_concurrent,
             agents_dir,
             no_tui,
@@ -121,6 +127,7 @@ async fn main() -> Result<()> {
                 copilot_cmd,
                 model,
                 runs_dir: PathBuf::from(&runs_dir),
+                repos_dir: PathBuf::from(&repos_dir),
                 max_concurrent,
                 agents_dir: PathBuf::from(&agents_dir).canonicalize().with_context(|| {
                     format!(
@@ -205,11 +212,17 @@ fn stage_status_text(stage: &pipeline::Stage, has_running_task: bool) -> String 
 }
 
 async fn run_start(config: Config, no_tui: bool) -> Result<()> {
-    // --- ensure runs dir ---------------------------------------------------
+    // --- ensure runs dir & repos dir ---------------------------------------
     std::fs::create_dir_all(&config.runs_dir).with_context(|| {
         format!(
             "failed to create runs directory at {}",
             config.runs_dir.display()
+        )
+    })?;
+    std::fs::create_dir_all(&config.repos_dir).with_context(|| {
+        format!(
+            "failed to create repos directory at {}",
+            config.repos_dir.display()
         )
     })?;
 
@@ -254,6 +267,7 @@ async fn run_start(config: Config, no_tui: bool) -> Result<()> {
     info!("  copilot_cmd    : {}", config.copilot_cmd);
     info!("  model          : {}", config.model);
     info!("  runs_dir       : {}", config.runs_dir.display());
+    info!("  repos_dir      : {}", config.repos_dir.display());
     info!("  max_concurrent : {}", config.max_concurrent);
     info!("=======================================================");
 
@@ -380,7 +394,7 @@ async fn run_start(config: Config, no_tui: bool) -> Result<()> {
                 issue = issue.number,
                 "new issue detected, creating pipeline"
             );
-            let p = pipeline::Pipeline::new(issue.number, config.repo.clone(), &config.runs_dir);
+            let p = pipeline::Pipeline::new(issue.number, config.repo.clone(), &config.runs_dir, &config.repos_dir);
             if let Err(e) = db.upsert_pipeline(&p) {
                 error!(
                     issue = issue.number,
@@ -414,12 +428,14 @@ async fn run_start(config: Config, no_tui: bool) -> Result<()> {
                     let repo = p.repo.clone();
                     let branch = p.branch_name.clone();
                     let worktree = p.worktree.clone();
+                    let bare_repo = p.bare_repo.clone();
                     let run_dir = p.run_dir.clone();
                     let inum = p.issue_number;
                     tokio::spawn(async move {
                         github::delete_remote_branch(&repo, &branch).await;
+                        // Remove worktree via git (falls back to rm internally).
                         if worktree.exists() {
-                            if let Err(e) = std::fs::remove_dir_all(&worktree) {
+                            if let Err(e) = github::remove_worktree(&bare_repo, &worktree).await {
                                 tracing::warn!(issue = inum, "cleanup: remove worktree: {:#}", e);
                             }
                         }

--- a/daemon/src/pipeline.rs
+++ b/daemon/src/pipeline.rs
@@ -114,6 +114,7 @@ pub struct Pipeline {
     pub stage: Stage,
     pub run_dir: PathBuf,
     pub worktree: PathBuf,
+    pub bare_repo: PathBuf,
     pub pr_number: Option<u64>,
     pub blocker_fingerprint: Option<String>,
     pub branch_name: String,
@@ -124,14 +125,17 @@ impl Pipeline {
     /// Create a new pipeline for the given issue.
     ///
     /// A run directory is created under `runs_dir` with the pattern
-    /// `{timestamp}-{repo_slug}-{issue_number}`.
-    pub fn new(issue_number: u64, repo: String, runs_dir: &Path) -> Self {
+    /// `{timestamp}-{repo_slug}-{issue_number}`.  The `bare_repo` path
+    /// is computed under `repos_dir` (shared bare clone per repo).
+    pub fn new(issue_number: u64, repo: String, runs_dir: &Path, repos_dir: &Path) -> Self {
         let timestamp = chrono::Utc::now().format("%Y%m%dT%H%M%SZ");
         let repo_slug = repo.replace('/', "-");
         let dir_name = format!("{}-{}-{}", timestamp, repo_slug, issue_number);
         let run_dir = runs_dir.join(&dir_name);
         let worktree = run_dir.join("worktree");
         let branch_name = format!("guild/issue-{}", issue_number);
+        let bare_name = format!("{}.git", repo_slug);
+        let bare_repo = repos_dir.join(&bare_name);
 
         fs::create_dir_all(&run_dir).expect("failed to create run_dir");
 
@@ -141,6 +145,7 @@ impl Pipeline {
             stage: Stage::Ingest,
             run_dir,
             worktree,
+            bare_repo,
             pr_number: None,
             blocker_fingerprint: None,
             branch_name,
@@ -188,21 +193,24 @@ impl Pipeline {
     /// Called after the pipeline has been recorded in the completed ledger.
     /// Errors are logged but not propagated -- cleanup is best-effort.
     #[allow(dead_code)]
-    pub fn cleanup_run(&self) {
-        // Remove worktree first (may be a large clone).
+    pub async fn cleanup_run(&self) {
+        // Remove worktree via git worktree remove (falls back to rm internally).
         if self.worktree.exists() {
-            if let Err(e) = fs::remove_dir_all(&self.worktree) {
-                tracing::warn!(
-                    issue = self.issue_number,
-                    path = %self.worktree.display(),
-                    "failed to remove worktree: {:#}", e
-                );
-            } else {
-                info!(
-                    issue = self.issue_number,
-                    path = %self.worktree.display(),
-                    "removed worktree"
-                );
+            match github::remove_worktree(&self.bare_repo, &self.worktree).await {
+                Ok(_) => {
+                    info!(
+                        issue = self.issue_number,
+                        path = %self.worktree.display(),
+                        "removed worktree"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        issue = self.issue_number,
+                        path = %self.worktree.display(),
+                        "failed to remove worktree: {:#}", e
+                    );
+                }
             }
         }
 
@@ -264,18 +272,32 @@ impl Pipeline {
     }
 
     pub async fn do_understand(&mut self) -> Result<bool> {
-        // Clean up stale git lock files that may have been left by a killed process.
-        let git_lock = self.worktree.join(".git/index.lock");
-        if git_lock.exists() {
-            info!("removing stale git lock file: {}", git_lock.display());
-            let _ = fs::remove_file(&git_lock);
-        }
-
-        // Clone repo into worktree if it doesn't already exist.
+        // Create worktree from bare repo if it doesn't already exist.
         if !self.worktree.exists() {
-            github::clone_repo(&self.repo, &self.worktree)
+            // Ensure bare clone exists and is up-to-date.
+            let repos_dir = self
+                .bare_repo
+                .parent()
+                .context("Understand: bare_repo has no parent directory")?;
+            let _bare = github::ensure_bare_repo(&self.repo, repos_dir)
                 .await
-                .context("Understand: failed to clone repo")?;
+                .context("Understand: failed to ensure bare repo")?;
+
+            // Create worktree with the working branch.
+            github::add_worktree(&self.bare_repo, &self.worktree, &self.branch_name)
+                .await
+                .context("Understand: failed to add worktree")?;
+        } else {
+            // Worktree already exists (e.g. daemon restart). Clean up stale
+            // lock files — in a worktree layout the git dir is different from
+            // `.git/` so we resolve it dynamically.
+            if let Ok(git_dir) = github::resolve_git_dir(&self.worktree).await {
+                let lock: PathBuf = git_dir.join("index.lock");
+                if lock.exists() {
+                    info!("removing stale git lock file: {}", lock.display());
+                    let _ = fs::remove_file(&lock);
+                }
+            }
         }
 
         // Scan for notable files.
@@ -347,11 +369,6 @@ impl Pipeline {
 
         fs::write(self.run_dir.join("repo_summary.md"), &summary)
             .context("Understand: failed to write repo_summary.md")?;
-
-        // Create branch.
-        github::checkout_or_create_branch(&self.worktree, &self.branch_name)
-            .await
-            .context("Understand: failed to checkout or create branch")?;
 
         info!("Repo understood, branch created: {}", self.branch_name);
 
@@ -472,10 +489,12 @@ impl Pipeline {
 
     pub async fn do_submit(&mut self) -> Result<bool> {
         // Clean up stale git lock file from a potentially killed process.
-        let git_lock = self.worktree.join(".git/index.lock");
-        if git_lock.exists() {
-            info!("removing stale git lock file: {}", git_lock.display());
-            let _ = fs::remove_file(&git_lock);
+        if let Ok(git_dir) = github::resolve_git_dir(&self.worktree).await {
+            let git_lock: PathBuf = git_dir.join("index.lock");
+            if git_lock.exists() {
+                info!("removing stale git lock file: {}", git_lock.display());
+                let _ = fs::remove_file(&git_lock);
+            }
         }
 
         let commit_msg = format!("guild: implement issue #{}", self.issue_number);
@@ -720,10 +739,12 @@ impl Pipeline {
 
     pub async fn do_fix(&mut self, config: &Config) -> Result<bool> {
         // Clean up stale git lock file from a potentially killed process.
-        let git_lock = self.worktree.join(".git/index.lock");
-        if git_lock.exists() {
-            info!("removing stale git lock file: {}", git_lock.display());
-            let _ = fs::remove_file(&git_lock);
+        if let Ok(git_dir) = github::resolve_git_dir(&self.worktree).await {
+            let git_lock: PathBuf = git_dir.join("index.lock");
+            if git_lock.exists() {
+                info!("removing stale git lock file: {}", git_lock.display());
+                let _ = fs::remove_file(&git_lock);
+            }
         }
 
         let blocker_report = read_file_or(


### PR DESCRIPTION
Closes #20

## Problem

Every pipeline run performs a full shallow clone of the target repository into its own `worktree/` directory. When the daemon handles multiple issues for the same repo concurrently, this duplicates the entire repo for each run — wasting disk space, network bandwidth, and time.

## Solution

Replaced `git clone` with `git worktree` backed by a shared bare clone per repo. A new `repos/` directory (configurable via `--repos-dir`) holds one bare clone per repository (`owner-repo.git`). Each pipeline run creates a lightweight git worktree from the bare clone instead of a full clone. This shares the object store across all concurrent runs for the same repo.

Key changes:
- **`github.rs`**: Added `ensure_bare_repo()` (clone or fetch a shared bare repo), `add_worktree()` (create worktree with branch), `remove_worktree()` (cleanup via `git worktree remove`), and `resolve_git_dir()` (find actual git dir for lock file cleanup in worktree layout). Removed `clone_repo()` and `checkout_or_create_branch()`.
- **`pipeline.rs`**: Added `bare_repo` field to `Pipeline`. Updated `new()` to accept `repos_dir`. `do_understand()` now calls `ensure_bare_repo` + `add_worktree` instead of `clone_repo` + `checkout_or_create_branch`. Fixed git lock file paths to work with worktree layout. `cleanup_run()` uses `remove_worktree()`.
- **`main.rs`**: Added `--repos-dir` CLI flag and `repos_dir` field to `Config`. Cleanup uses `remove_worktree()`.
- **`db.rs`**: Added `bare_repo` column to pipelines table with migration for existing databases.
- **`README.md`**: Updated architecture diagram and stage descriptions to reflect the worktree approach.


---
*Generated by [guild](https://github.com/KaugaKauga/guild)*