### PR TITLE
guild: Code styling / linting 2 (#51)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup default stable
+      - run: rustup component add rustfmt clippy
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: daemon
+      - run: cargo fmt --check
+      - run: cargo clippy -- -D warnings
       - run: cargo test

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+# Clippy configuration for the guild project.
+# Using default settings. Add overrides here as needed.

--- a/daemon/src/db.rs
+++ b/daemon/src/db.rs
@@ -65,12 +65,7 @@ impl Db {
             "issue_title",
             "TEXT NOT NULL DEFAULT ''",
         )?;
-        Self::migrate_add_column(
-            &conn,
-            "pipelines",
-            "bare_repo",
-            "TEXT NOT NULL DEFAULT ''",
-        )?;
+        Self::migrate_add_column(&conn, "pipelines", "bare_repo", "TEXT NOT NULL DEFAULT ''")?;
 
         info!(path = %path.display(), "database opened");
 

--- a/daemon/src/github.rs
+++ b/daemon/src/github.rs
@@ -294,8 +294,9 @@ pub async fn remove_worktree(bare_repo: &Path, worktree_dest: &Path) -> Result<(
             "git worktree remove failed, falling back to rm + prune"
         );
         if worktree_dest.exists() {
-            std::fs::remove_dir_all(worktree_dest)
-                .with_context(|| format!("failed to remove worktree at {}", worktree_dest.display()))?;
+            std::fs::remove_dir_all(worktree_dest).with_context(|| {
+                format!("failed to remove worktree at {}", worktree_dest.display())
+            })?;
         }
         let _ = run_git(&["worktree", "prune"], bare_repo).await;
     }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -229,10 +229,16 @@ async fn run_start(mut config: Config, no_tui: bool) -> Result<()> {
     // Canonicalize to absolute paths so that relative paths resolve correctly
     // when git commands run with a different current_dir (e.g. bare repo).
     config.runs_dir = config.runs_dir.canonicalize().with_context(|| {
-        format!("failed to canonicalize runs_dir: {}", config.runs_dir.display())
+        format!(
+            "failed to canonicalize runs_dir: {}",
+            config.runs_dir.display()
+        )
     })?;
     config.repos_dir = config.repos_dir.canonicalize().with_context(|| {
-        format!("failed to canonicalize repos_dir: {}", config.repos_dir.display())
+        format!(
+            "failed to canonicalize repos_dir: {}",
+            config.repos_dir.display()
+        )
     })?;
 
     // --- tracing -----------------------------------------------------------
@@ -403,7 +409,12 @@ async fn run_start(mut config: Config, no_tui: bool) -> Result<()> {
                 issue = issue.number,
                 "new issue detected, creating pipeline"
             );
-            let p = pipeline::Pipeline::new(issue.number, config.repo.clone(), &config.runs_dir, &config.repos_dir);
+            let p = pipeline::Pipeline::new(
+                issue.number,
+                config.repo.clone(),
+                &config.runs_dir,
+                &config.repos_dir,
+            );
             if let Err(e) = db.upsert_pipeline(&p) {
                 error!(
                     issue = issue.number,

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2021"
+max_width = 100


### PR DESCRIPTION
Closes #51

## Problem

Contributors reformat code based on personal editor settings, causing back-and-forth formatting churn in PRs. There is no shared formatter or linter configuration, and CI does not enforce any code style.

## Solution

Added `rustfmt.toml` and `clippy.toml` at the repo root to establish a shared formatting and linting configuration. Ran `cargo fmt` to normalize all existing code to the agreed style (edition 2021, max width 100). Updated `.github/workflows/ci.yml` to run `cargo fmt --check` and `cargo clippy -- -D warnings` before tests, so style violations and lint warnings block merges. All existing code already passes both checks with zero changes needed beyond formatting.


---
*Generated by [guild](https://github.com/KaugaKauga/guild)*