### PR TITLE
familiar: Change CLI artwork (#57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,23 @@
 # Familiar
 
-An autonomous software factory. Point it at a GitHub repo, label an issue, and
-Familiar will implement the change, open a draft PR, and keep fixing it until CI is
-green — with no human in the loop.
+> *In folklore, a **familiar** is a spirit companion — often in the shape of a cat,
+> owl, or raven — that serves a practitioner of magic, carrying out their will.*
+
+Your familiar is a tireless spirit bound to your GitHub repo. Point it at a
+repository, label an issue, and your familiar will carry out the work — writing
+code, opening a draft PR, and tending to it until CI is green — while you rest.
 
 ## What it does
 
-Familiar is a Rust daemon that continuously monitors a GitHub repository for issues
-carrying a specific label (default: `familiar`). When it finds one, it drives the
-issue through a fully automated pipeline that ends with a reviewed, green pull
-request.
+Familiar is a Rust daemon that watches over a GitHub repository, waiting for issues
+marked with a special label (default: `familiar`). When it senses one, it takes the
+issue under its wing and drives it through a fully automated pipeline that ends with
+a reviewed, green pull request.
 
-The daemon itself is **thin glue**. It handles orchestration, state, and
-GitHub interaction. All the actual thinking — what to implement, how to fix a
-test, how to respond to a review — is delegated to an external **agent CLI**
+The daemon itself is **thin glue** — the summoning circle, not the spirit. It
+handles orchestration, state, and GitHub interaction. All the actual thinking —
+what to implement, how to fix a test, how to respond to a review — is delegated
+to an external **agent CLI**
 running in non-interactive mode with full permissions. Two backends are
 supported out of the box — **GitHub Copilot CLI** (`copilot --yolo`) and
 **Anthropic Claude CLI** (`claude --permission-mode bypassPermissions`) —
@@ -208,27 +212,28 @@ spinners can't corrupt the TUI.
 
 ### Separation of concerns
 
-The daemon makes **zero** implementation decisions. It only decides *when* to invoke
+The daemon makes **zero** implementation decisions. It only decides *when* to summon
 the agent and *what context* to provide. All intelligence — what code to write, how
-to fix a test, how to address a review comment — lives in the agent process.
+to fix a test, how to address a review comment — lives in the spirit it calls upon.
 
 ### Repo learnings
 
-Familiar maintains a lightweight feedback loop via `.familiar/learnings.md` in the target
-repository. During the **UNDERSTAND** stage, the daemon reads this file (if it exists)
-and injects its contents into every agent prompt (PLAN, IMPLEMENT, FIX). This gives
-agents repo-specific context — build quirks, naming conventions, test patterns, common
-gotchas — without requiring human curation.
+Your familiar remembers what it learns. It maintains a lightweight memory via
+`.familiar/learnings.md` in the target repository. During the **UNDERSTAND** stage,
+the daemon reads this file (if it exists) and whispers its contents into every agent
+prompt (PLAN, IMPLEMENT, FIX). This gives agents repo-specific context — build
+quirks, naming conventions, test patterns, common gotchas — without requiring human
+curation.
 
-At the end of **IMPLEMENT** and **FIX**, agents are instructed to reflect on anything
-non-obvious they discovered and append it to `.familiar/learnings.md`. The file is
-committed alongside the rest of the code changes, so learnings accumulate over time
-and are available to future Familiar runs on the same repo.
+At the end of **IMPLEMENT** and **FIX**, the familiar reflects on anything non-obvious
+it discovered and appends it to `.familiar/learnings.md`. The file is committed
+alongside the rest of the code changes, so the familiar's knowledge deepens over
+time and carries forward to future summonings on the same repo.
 
 ## Design principles
 
-1. **The agent reads everything.** Don't pre-parse or summarize. Hand it the raw issue, the raw repo tree, the raw CI output.
+1. **The familiar reads everything.** Don't pre-parse or summarize. Hand it the raw issue, the raw repo tree, the raw CI output.
 2. **Never mark a PR ready.** The daemon creates draft PRs only. A human decides when to merge.
-3. **Never silence a failing check.** If the agent can't fix it, the pipeline retries. If it's truly stuck, the daemon keeps polling until a human intervenes.
-4. **State survives restarts.** Kill the daemon at any point, restart it, and it picks up where it left off.
-5. **`@familiar` is the control surface.** Comment on the PR to direct the agent. Everything else is ignored.
+3. **Never silence a failing check.** If the familiar can't fix it, it retries. If truly stuck, it keeps watch until a human intervenes.
+4. **State survives restarts.** Banish the daemon at any point, re-summon it, and it picks up where it left off.
+5. **`@familiar` is the control surface.** Comment on the PR to direct your familiar. Everything else is ignored.

--- a/daemon/src/banner.rs
+++ b/daemon/src/banner.rs
@@ -5,31 +5,26 @@ use crossterm::ExecutableCommand;
 use std::io::stdout;
 
 const BANNER: &str = r#"
-                      /\       /\
-                     /  \_/\__/  \
-                    / \  _/\_  / \
-                   /   \/    \/   \
-                  / /|          |\ \
-                 / / | FAMILIAR | \ \
-                / /  |  HOUSE   |  \ \
-               /_/  /||  ||  ||\   \_\
-              |  | / ||  ||  || \ |  |
-              |🔮| | |+--++--+| | |📖|
-              |  | | ||/\||/\|| | |  |
-              |  |_| ||''||''|| |_|  |
-              |  |   |+--++--+|   |  |
-              | .|   ||  ()  ||   |. |
-              |/ |   ||      ||   | \|
-             /|  |   |+------+|   |  |\
-            /_|__|___|________|___|__|_\
-           |  ~~  {come in, we're open}  |
-           |_____________________________|
+                          /\_/\
+                     ____/ o o \
+                   /~____  =ω=  /
+                  (______)__m_m_/
+                   |     /  \/
+                   |    /  __\
+                   |   / /'  `\
+                   |  / /      \
+              .-~~~|_/ /~~~~~~~~`-.
+             /  ✦  .  .  ✦  .  ✦  \
+            :  .  ✦  .  ✦  .  ✦  . :
+             \ ✦  .  ✦  .  ✦  .  ✦/
+              `-.____.~~~~.____.-'
+                   ╱  FAMILIAR  ╲
 "#;
 
 const TAGLINE: &str = r#"
     ┌─────────────────────────────────────────────────────────────────┐
-    │  "From issue to pull request, your familiar works through the  │
-    │   night so you don't have to."                                 │
+    │  Summoned by a label, your familiar toils through the night —  │
+    │  from issue to pull request, while you rest.                   │
     └─────────────────────────────────────────────────────────────────┘
 "#;
 
@@ -37,7 +32,7 @@ const TAGLINE: &str = r#"
 pub fn print_banner() {
     let mut out = stdout();
 
-    let _ = out.execute(SetForegroundColor(Color::DarkYellow));
+    let _ = out.execute(SetForegroundColor(Color::Magenta));
     let _ = out.execute(Print(BANNER));
     let _ = out.execute(SetForegroundColor(Color::Cyan));
     let _ = out.execute(Print(TAGLINE));

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -20,7 +20,7 @@ use tui::{DaemonState, PipelineSnapshot};
 // CLI
 // ---------------------------------------------------------------------------
 
-/// Familiar — an autonomous software factory.
+/// Familiar — a spectral companion that does your bidding.
 #[derive(Parser, Debug)]
 #[command(name = "familiar", version, about)]
 struct Cli {
@@ -30,7 +30,7 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Commands {
-    /// Start the familiar daemon with a live interactive dashboard.
+    /// Summon your familiar with a live interactive dashboard.
     Start {
         /// GitHub repo in owner/repo format (positional or --repo)
         #[arg(value_name = "REPO")]
@@ -282,12 +282,12 @@ async fn run_start(mut config: Config, no_tui: bool) -> Result<()> {
     // --- print banner (before TUI takes over the screen) -------------------
     if !no_tui {
         banner::print_banner();
-        println!("  Starting daemon for {}...\n", config.repo);
+        println!("  Summoning familiar for {}...\n", config.repo);
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
     }
 
     info!("=======================================================");
-    info!("  Familiar daemon starting");
+    info!("  Familiar spirit awakening");
     info!("  repo           : {}", config.repo);
     info!("  label          : {}", config.label);
     info!("  poll_interval  : {}s", config.poll_interval);
@@ -709,7 +709,7 @@ async fn run_start(mut config: Config, no_tui: bool) -> Result<()> {
         tokio::time::sleep(std::time::Duration::from_secs(config.poll_interval)).await;
     }
 
-    info!("familiar daemon shut down cleanly");
+    info!("familiar spirit returns to slumber");
     Ok(())
 }
 fn cleanup_orphan_run_dirs(runs_dir: &std::path::Path, db: &db::Db) {

--- a/daemon/src/tui.rs
+++ b/daemon/src/tui.rs
@@ -1,8 +1,9 @@
 //! Terminal UI dashboard for the Familiar daemon.
 //!
 //! Renders a live table of active pipelines showing issue number, stage,
-//! progress bar, and branch name.  Driven by a `tokio::sync::watch` channel
-//! that receives `DaemonState` updates from the main daemon loop.
+//! progress bar, and branch name.  Your familiar's scrying glass — driven
+//! by a `tokio::sync::watch` channel that receives `DaemonState` updates
+//! from the main daemon loop.
 
 use std::io::{self, stdout};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -248,13 +249,13 @@ fn render_header(frame: &mut ratatui::Frame, area: Rect, state: &DaemonState) {
 
     let header = Paragraph::new(Line::from(vec![
         Span::styled(
-            " ⚒️  FAMILIAR ",
+            " 🐈‍⬛ FAMILIAR ",
             Style::default()
                 .fg(Color::Yellow)
                 .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
-            "— Autonomous Software Factory  ",
+            "— Your Ghostly Companion  ",
             Style::default().fg(Color::DarkGray),
         ),
         Span::styled(
@@ -288,7 +289,7 @@ fn render_pipeline_table(
 ) {
     if state.pipelines.is_empty() {
         let empty = Paragraph::new(Line::from(vec![Span::styled(
-            "  No active pipelines — waiting for labeled issues...",
+            "  No active pipelines — your familiar awaits a summoning...",
             Style::default()
                 .fg(Color::DarkGray)
                 .add_modifier(Modifier::ITALIC),

--- a/starter.md
+++ b/starter.md
@@ -1,12 +1,12 @@
-You are helping me build my own "software factory" — an autonomous loop that
-takes a Github Issue and drives it to a reviewed, green pull request with
-minimal human intervention.
+You are helping me build a **familiar** — a loyal spirit companion that takes a
+GitHub Issue and carries it to a reviewed, green pull request while I rest.
 
-I want YOU (Copilot) to do the thinking. I will only write the thinnest
-possible glue to pass data between stages. Any decision — what to implement,
-how to react to a CI failure, how to respond to a review comment — is yours.
+I want YOU (Copilot) to be the familiar — to do the thinking and the work. I
+will only write the thinnest possible glue to pass data between stages. Any
+decision — what to implement, how to react to a CI failure, how to respond to
+a review comment — is yours.
 
-The factory runs in stages:
+The familiar works in stages:
 
 1. INGEST — pull the github issue via the gh cli. Read description,
    acceptance criteria, comments, linked tickets.


### PR DESCRIPTION
Closes #57

## Problem

The project is called "Familiar" but its wording uses industrial/mechanical metaphors like "autonomous software factory" and its ASCII banner depicts a house/shop. The theme should reflect the folklore concept of a familiar — a loyal spirit companion — with no robots or human-looking imagery.

## Solution

Rethemed all user-facing text across 5 files to embrace the companion spirit / familiar folklore theme:

- **banner.rs**: Replaced the house ASCII art with a spectral cat familiar, updated the tagline to summoning/spirit language, changed banner color from `DarkYellow` to `Magenta`
- **tui.rs**: Changed header from "Autonomous Software Factory" to "Your Ghostly Companion", swapped hammer emoji for black cat, updated empty-state text to use "summoning" language
- **main.rs**: Updated CLI description, log messages, and startup text to use spirit/companion wording ("summoning", "spirit awakening", "returns to slumber")
- **README.md**: Rewrote opening with folklore context, replaced factory metaphors throughout with familiar/spirit/companion language while preserving all technical content
- **starter.md**: Reframed the opening from "software factory" to "loyal spirit companion"

No functional behavior changes. All 35 existing tests pass, clippy clean.


---
*Generated by [familiar](https://github.com/KaugaKauga/guild)*