### PR TITLE
familiar: Token consumption reduction (#58)

### DIFF
--- a/agents/caveman.md
+++ b/agents/caveman.md
@@ -1,0 +1,12 @@
+Respond terse like smart caveman. All technical substance stay. Only fluff die.
+
+Rules:
+- Drop: articles (a/an/the), filler (just/really/basically), pleasantries, hedging
+- Fragments OK. Short synonyms. Technical terms exact. Code unchanged.
+- Pattern: [thing] [action] [reason]. [next step].
+- Not: "Sure! I'd be happy to help you with that."
+- Yes: "Bug in auth middleware. Fix:"
+
+Auto-Clarity: drop caveman for security warnings, irreversible actions, user confused. Resume after.
+
+Boundaries: code/commits/PRs written normal.

--- a/daemon/src/pipeline.rs
+++ b/daemon/src/pipeline.rs
@@ -32,6 +32,12 @@ pub fn load_agent_prompt(
         prompt = prompt.replace(&placeholder, value);
     }
 
+    // Prepend caveman token-compression instructions if available.
+    let caveman_path = agents_dir.join("caveman.md");
+    if let Ok(caveman) = fs::read_to_string(&caveman_path) {
+        prompt = format!("{caveman}\n\n---\n\n{prompt}");
+    }
+
     Ok(prompt)
 }
 
@@ -1111,6 +1117,38 @@ mod tests {
 
         let missing = dir.join("nonexistent.md");
         assert_eq!(parse_verify_verdict(&missing), VerifyVerdict::Fail);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_agent_prompt_prepends_caveman() {
+        let dir = std::env::temp_dir().join("familiar_test_caveman");
+        let _ = fs::create_dir_all(&dir);
+
+        fs::write(dir.join("plan.md"), "Plan for: {issue}").unwrap();
+        fs::write(dir.join("caveman.md"), "Respond terse.").unwrap();
+
+        let result = load_agent_prompt(&dir, "plan", &[("issue", "test bug")]).unwrap();
+
+        assert!(result.starts_with("Respond terse."));
+        assert!(result.contains("---"));
+        assert!(result.contains("Plan for: test bug"));
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_agent_prompt_works_without_caveman() {
+        let dir = std::env::temp_dir().join("familiar_test_no_caveman");
+        let _ = fs::create_dir_all(&dir);
+
+        fs::write(dir.join("plan.md"), "Plan for: {issue}").unwrap();
+        // No caveman.md — should work fine without it.
+
+        let result = load_agent_prompt(&dir, "plan", &[("issue", "test bug")]).unwrap();
+
+        assert_eq!(result, "Plan for: test bug");
 
         let _ = fs::remove_dir_all(&dir);
     }


### PR DESCRIPTION
Closes #58

## Problem

LLM responses consume excessive output tokens with filler words, pleasantries, and hedging that add no technical value. This increases cost and latency across both Copilot and Claude backends.

## Solution

Integrated [Caveman](https://github.com/juliusbrussee/caveman) token compression by adding `agents/caveman.md` with terse-response instructions, and modifying `load_agent_prompt()` in `daemon/src/pipeline.rs` to automatically prepend these instructions to every agent prompt. This activates for all stages (plan, implement, verify, fix) and both backends with zero per-backend changes. If `caveman.md` is removed, behavior reverts to normal — no hard dependency.


---
*Generated by [familiar](https://github.com/KaugaKauga/guild)*