### PR TITLE
familiar: Adjust model (#61)

### DIFF
--- a/daemon/src/agent/mod.rs
+++ b/daemon/src/agent/mod.rs
@@ -259,32 +259,50 @@ mod tests {
     #[test]
     fn copilot_default_planning_model_is_opus() {
         let model = Backend::Copilot.default_planning_model();
-        assert!(model.contains("opus"), "planning model should be opus, got: {model}");
+        assert!(
+            model.contains("opus"),
+            "planning model should be opus, got: {model}"
+        );
     }
 
     #[test]
     fn copilot_default_coding_model_is_sonnet() {
         let model = Backend::Copilot.default_coding_model();
-        assert!(model.contains("sonnet"), "coding model should be sonnet, got: {model}");
+        assert!(
+            model.contains("sonnet"),
+            "coding model should be sonnet, got: {model}"
+        );
     }
 
     #[test]
     fn claude_default_planning_model_is_opus() {
         let model = Backend::Claude.default_planning_model();
-        assert!(model.contains("opus"), "planning model should be opus, got: {model}");
+        assert!(
+            model.contains("opus"),
+            "planning model should be opus, got: {model}"
+        );
     }
 
     #[test]
     fn claude_default_coding_model_is_sonnet() {
         let model = Backend::Claude.default_coding_model();
-        assert!(model.contains("sonnet"), "coding model should be sonnet, got: {model}");
+        assert!(
+            model.contains("sonnet"),
+            "coding model should be sonnet, got: {model}"
+        );
     }
 
     #[test]
     fn default_model_matches_planning_model() {
         // default_model() is a legacy alias for the planning model
-        assert_eq!(Backend::Copilot.default_model(), Backend::Copilot.default_planning_model());
-        assert_eq!(Backend::Claude.default_model(), Backend::Claude.default_planning_model());
+        assert_eq!(
+            Backend::Copilot.default_model(),
+            Backend::Copilot.default_planning_model()
+        );
+        assert_eq!(
+            Backend::Claude.default_model(),
+            Backend::Claude.default_planning_model()
+        );
     }
 
     #[test]

--- a/daemon/src/agent/mod.rs
+++ b/daemon/src/agent/mod.rs
@@ -44,9 +44,22 @@ impl Backend {
 
     /// Default model identifier if the user did not pass `--model`.
     pub fn default_model(self) -> &'static str {
+        self.default_planning_model()
+    }
+
+    /// Default model for the Plan stage (expensive, high-quality reasoning).
+    pub fn default_planning_model(self) -> &'static str {
         match self {
             Backend::Copilot => "claude-opus-4.6",
             Backend::Claude => "claude-opus-4-7",
+        }
+    }
+
+    /// Default model for Implement, Verify, and Fix stages (cheaper, fast).
+    pub fn default_coding_model(self) -> &'static str {
+        match self {
+            Backend::Copilot => "claude-sonnet-4.6",
+            Backend::Claude => "claude-sonnet-4-6",
         }
     }
 }
@@ -237,4 +250,52 @@ fn read_tail(path: &Path, n: usize) -> String {
     let lines: Vec<&str> = buf.lines().collect();
     let start = lines.len().saturating_sub(n);
     lines[start..].join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn copilot_default_planning_model_is_opus() {
+        let model = Backend::Copilot.default_planning_model();
+        assert!(model.contains("opus"), "planning model should be opus, got: {model}");
+    }
+
+    #[test]
+    fn copilot_default_coding_model_is_sonnet() {
+        let model = Backend::Copilot.default_coding_model();
+        assert!(model.contains("sonnet"), "coding model should be sonnet, got: {model}");
+    }
+
+    #[test]
+    fn claude_default_planning_model_is_opus() {
+        let model = Backend::Claude.default_planning_model();
+        assert!(model.contains("opus"), "planning model should be opus, got: {model}");
+    }
+
+    #[test]
+    fn claude_default_coding_model_is_sonnet() {
+        let model = Backend::Claude.default_coding_model();
+        assert!(model.contains("sonnet"), "coding model should be sonnet, got: {model}");
+    }
+
+    #[test]
+    fn default_model_matches_planning_model() {
+        // default_model() is a legacy alias for the planning model
+        assert_eq!(Backend::Copilot.default_model(), Backend::Copilot.default_planning_model());
+        assert_eq!(Backend::Claude.default_model(), Backend::Claude.default_planning_model());
+    }
+
+    #[test]
+    fn planning_and_coding_models_differ() {
+        assert_ne!(
+            Backend::Copilot.default_planning_model(),
+            Backend::Copilot.default_coding_model(),
+        );
+        assert_ne!(
+            Backend::Claude.default_planning_model(),
+            Backend::Claude.default_coding_model(),
+        );
+    }
 }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -57,9 +57,17 @@ enum Commands {
         #[arg(long, alias = "copilot-cmd")]
         agent_cmd: Option<String>,
 
-        /// AI model to use. Defaults to a sensible model per backend if unset.
+        /// AI model for all stages (overrides --planning-model and --coding-model).
         #[arg(short = 'm', long)]
         model: Option<String>,
+
+        /// AI model for the Plan stage. Defaults to an opus-class model.
+        #[arg(long)]
+        planning_model: Option<String>,
+
+        /// AI model for Implement, Verify, and Fix stages. Defaults to a sonnet-class model.
+        #[arg(long)]
+        coding_model: Option<String>,
 
         /// Directory where run artifacts are stored
         #[arg(long, default_value = "./runs")]
@@ -98,7 +106,8 @@ pub struct Config {
     pub poll_interval: u64,
     pub backend: Backend,
     pub agent_cmd: String,
-    pub model: String,
+    pub planning_model: String,
+    pub coding_model: String,
     pub runs_dir: PathBuf,
     pub repos_dir: PathBuf,
     pub max_concurrent: usize,
@@ -118,6 +127,8 @@ async fn main() -> Result<()> {
             backend,
             agent_cmd,
             model,
+            planning_model,
+            coding_model,
             runs_dir,
             repos_dir,
             max_concurrent,
@@ -129,7 +140,15 @@ async fn main() -> Result<()> {
                 .expect("repo is required: familiar start <owner/repo>");
 
             let agent_cmd = agent_cmd.unwrap_or_else(|| backend.default_cmd().to_string());
-            let model = model.unwrap_or_else(|| backend.default_model().to_string());
+
+            // --model overrides both; otherwise per-stage defaults apply.
+            let planning_model = model
+                .clone()
+                .or(planning_model)
+                .unwrap_or_else(|| backend.default_planning_model().to_string());
+            let coding_model = model
+                .or(coding_model)
+                .unwrap_or_else(|| backend.default_coding_model().to_string());
 
             let config = Config {
                 repo,
@@ -137,7 +156,8 @@ async fn main() -> Result<()> {
                 poll_interval,
                 backend,
                 agent_cmd,
-                model,
+                planning_model,
+                coding_model,
                 runs_dir: PathBuf::from(&runs_dir),
                 repos_dir: PathBuf::from(&repos_dir),
                 max_concurrent,
@@ -293,7 +313,8 @@ async fn run_start(mut config: Config, no_tui: bool) -> Result<()> {
     info!("  poll_interval  : {}s", config.poll_interval);
     info!("  backend        : {}", config.backend);
     info!("  agent_cmd      : {}", config.agent_cmd);
-    info!("  model          : {}", config.model);
+    info!("  planning_model : {}", config.planning_model);
+    info!("  coding_model   : {}", config.coding_model);
     info!("  runs_dir       : {}", config.runs_dir.display());
     info!("  repos_dir      : {}", config.repos_dir.display());
     info!("  max_concurrent : {}", config.max_concurrent);

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -29,6 +29,7 @@ struct Cli {
 }
 
 #[derive(Subcommand, Debug)]
+#[allow(clippy::large_enum_variant)]
 enum Commands {
     /// Start the familiar daemon with a live interactive dashboard.
     Start {

--- a/daemon/src/pipeline.rs
+++ b/daemon/src/pipeline.rs
@@ -403,7 +403,7 @@ impl Pipeline {
         agent::run(
             config.backend,
             &config.agent_cmd,
-            &config.model,
+            &config.planning_model,
             &prompt_path,
             &self.worktree,
             &self.run_dir,
@@ -453,7 +453,7 @@ impl Pipeline {
         agent::run(
             config.backend,
             &config.agent_cmd,
-            &config.model,
+            &config.coding_model,
             &prompt_path,
             &self.worktree,
             &self.run_dir,
@@ -484,7 +484,7 @@ impl Pipeline {
         agent::run(
             config.backend,
             &config.agent_cmd,
-            &config.model,
+            &config.coding_model,
             &prompt_path,
             &self.worktree,
             &self.run_dir,
@@ -813,7 +813,7 @@ impl Pipeline {
         agent::run(
             config.backend,
             &config.agent_cmd,
-            &config.model,
+            &config.coding_model,
             &prompt_path,
             &self.worktree,
             &self.run_dir,


### PR DESCRIPTION
Closes #61

## Problem

All pipeline stages (Plan, Implement, Verify, Fix) use the same AI model — defaulting to opus, which is expensive. The planning stage needs opus-class reasoning, but implementation and verification stages work fine with cheaper sonnet-class models.

## Solution

Replaced the single `model` field in `Config` with `planning_model` and `coding_model`. The Plan stage uses `planning_model` (defaults to opus), while Implement, Verify, and Fix stages use `coding_model` (defaults to sonnet 4.6). Added `--planning-model` and `--coding-model` CLI flags for granular control. The existing `--model` / `-m` flag is preserved as an override that sets both. Added 6 unit tests for the new Backend model methods.


---
*Generated by [familiar](https://github.com/KaugaKauga/guild)*